### PR TITLE
fix base URL

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = "https://TangoPortugal.github.io/tango-portugal"
+baseURL = "https://tangoportugal.com"
 title = "Alejandro Laguna"
 theme = "hugoplate"
 timeZone = "Europe/Lisbon"


### PR DESCRIPTION
This pull request updates the `baseURL` in the Hugo configuration file to use the new production domain.

- Configuration update:
  * Changed the `baseURL` in `hugo.toml` from the GitHub Pages URL to the new custom domain `https://tangoportugal.com`.